### PR TITLE
feat: conventional commits for mlops

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,13 @@ exclude: ".md$"
 repos:
   - repo: local
     hooks:
+      - id: conventional-commits-mlops
+        name: Conventional Commits for MlOps
+        entry: ./hooks/conventional_commits_for_mlops.py
+        language: script
+        description: Checks if commit message follows the commit guidelines for MlOps
+        stages: [commit-msg]
+        always_run: true
       - id: check-merge-conflict
         name: check for merge conflicts
         description: checks for files that contain merge conflict strings.

--- a/hooks/conventional_commits_for_mlops.py
+++ b/hooks/conventional_commits_for_mlops.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+
+import sys
+import re
+
+SEMANTIC_PREFIXES = [
+    "feat",
+    "fix",
+    "ci",
+    "revert",
+    "model",
+    "docs",
+    "style",
+    "refactor",
+    "test",
+    "perf",
+]
+
+
+def check_msg_size(msg):
+    """Check if the commit message is too long."""
+    if len(msg) > 72:
+        print(
+            "ERROR: Commit message is too long. It should be 72 characters or"
+            " less."
+        )
+        return False
+    return True
+
+
+def check_msg_prefix(msg):
+    """Check if the header of the commit message starts with one of the
+    semantic prefixes. That is, the commit message should be of the form
+    '<prefix>(optional): <message>'
+
+    Parameters
+    ----------
+    header_msg : str
+        The commit message header.
+
+    """
+    if all(
+        [
+            not re.match(f"^{prefix}(\\(.*?\\))?\\!?\\:", msg)
+            for prefix in SEMANTIC_PREFIXES
+        ]
+    ):
+        print(
+            "ERROR: Commit message does not start with a semantic prefix.",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def check_header_is_meaningful(msg):
+    """Check if the commit message header is meaningful.
+
+    Parameters
+    ----------
+    header : str
+        The commit message header.
+
+    Returns
+    -------
+    prefix : str
+        The prefix of the commit message header.
+    message : str
+        The message of the commit message header.
+    """
+    if len(msg.split(":")) < 2:
+        print(
+            "ERROR: Commit message header is not meaningful. It should be of"
+            " the form '<prefix>(optional): <message>'",
+            file=sys.stderr,
+        )
+        return False
+
+    prefix, info = msg.split(": ", 1)
+    if len(info.split()) < 3:
+        print("ERROR: Commit message is too short.", file=sys.stderr)
+        return False
+    print(prefix, info)
+    return True
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.exit(0)
+
+    msg_lines = open(sys.argv[1], "r").readlines()
+    if len(msg_lines) == 0:
+        print("ERROR: Commit message does not have a header.", file=sys.stderr)
+        sys.exit(1)
+
+    header = msg_lines[0]
+
+    if not check_msg_size(header):
+        sys.exit(1)
+    if not check_msg_prefix(header):
+        sys.exit(1)
+    if not check_header_is_meaningful(header):
+        sys.exit(1)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,31 @@
+from hooks.conventional_commits_for_mlops import (
+    check_msg_size,
+    check_msg_prefix,
+    check_header_is_meaningful,
+)
+
+
+def test_msg_size():
+    """Test commit message size."""
+    long_msg = "a" * 80
+    short_msg = "a" * 70
+    assert not check_msg_size(long_msg)
+    assert check_msg_size(short_msg)
+
+
+def test_msg_prefix():
+    """Test commit message prefix."""
+    assert not check_msg_prefix("update README.md")
+    assert not check_msg_prefix("fix update README.md")
+    assert check_msg_prefix("fix: update README.md")
+    assert check_msg_prefix("fix(something): update README.md")
+    assert check_msg_prefix("fix(something)!: update README.md")
+    assert check_msg_prefix("fix!: update README.md")
+
+
+def test_header_is_meanigful():
+    """Test commit message header is meaningful."""
+    assert not check_header_is_meaningful("fix: update README.md")
+    assert check_header_is_meaningful(
+        "feat(api)!: send an email to the customer when a product is shipped"
+    )


### PR DESCRIPTION
This PR aims to help the contributors to follow a set of guidelines for writing good commit messages.  Also, this is a very simple hook in which the beginners can learn how to write a simple pre-commit task.

This will check the commit messages following
some guidelines. We can improve this latter by adding new behaviors

From now on, we have just simple checks.
- Prefixes: `feat, fix , feat(scope), docs!:`
-  Blocks long msgs.
-  Blocks short commit messages.

## Refs:

https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines

https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716
