### PR TITLE
fix pip22 bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ pip-compile: install-pip-tools
 
 ## Install Python Dependencies & Install pre-commit hooks
 requirements: pip-compile check_installed_python
-	$(PYTHON_INTERPRETER) -m pip install --upgrade pip &&\
+	$(PYTHON_INTERPRETER) -m pip install --upgrade pip==21.3.1 &&\
 	$(PYTHON_INTERPRETER) -m pip install -r requirements-dev.txt --use-deprecated=legacy-resolver &&\
 	pre-commit install
 	$(PYTHON_INTERPRETER) -m pip install -r requirements.txt --use-deprecated=legacy-resolver


### PR DESCRIPTION
When you run the comand

`make requirements`

The makefile installs the pip=22.0.1 which has a bug with the pip-compile.

This will temporarily freeze the pip version installed by the makefile to pip=21.3.1