### PR TITLE
fix: perform pip-downgrade before the pip-compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CONFIG_KEY_NAME=required_python
 
 # Test if python is installed
 
-ifeq (,$(shell $(PYTHON_INTERPRETER) --version))
+ifeq (,$(shell python3 --version))
 $(error "Python is not installed!")
 endif
 
@@ -55,9 +55,11 @@ pip-compile: install-pip-tools
 	pip-compile --no-emit-index-url requirements.in
 	pip-compile --no-emit-index-url requirements-dev.in
 
+pip-downgrade:
+	$(PYTHON_INTERPRETER) -m pip install pip==21.3.1
+
 ## Install Python Dependencies & Install pre-commit hooks
-requirements: pip-compile check_installed_python
-	$(PYTHON_INTERPRETER) -m pip install --upgrade pip==21.3.1 &&\
+requirements: pip-downgrade pip-compile check_installed_python
 	$(PYTHON_INTERPRETER) -m pip install -r requirements-dev.txt --use-deprecated=legacy-resolver &&\
 	pre-commit install
 	$(PYTHON_INTERPRETER) -m pip install -r requirements.txt --use-deprecated=legacy-resolver

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CONFIG_KEY_NAME=required_python
 
 # Test if python is installed
 
-ifeq (,$(shell python3 --version))
+ifeq (,$(shell $(PYTHON_INTERPRETER) --version))
 $(error "Python is not installed!")
 endif
 


### PR DESCRIPTION
We should replace `pip-downgrade` by a `pip-upgrade` task
after `pip-tools` team's solution be merged and released. 

After the bug been fixed, we should have the following
```sh
pip-uprade:
	$(PYTHON_INTERPRETER) -m pip install --upgrade
	
## Install Python Dependencies & Install pre-commit hooks
requirements: pip-upgrade pip-compile check_installed_python
```