### PR TITLE
fix: make clean behavior for empty folders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,8 +84,8 @@ data: get_data
 clean:
 	@find . -type f -name "*.py[co]" -delete
 	@find . -type d -name "__pycache__" -delete
-	@find . -type d -name ".tox" -exec rm -rf "{}" \;
-	@find . -type d -name ".pytest_cache" -exec rm -rf "{}" \;
+	@find . -type d -name ".tox" -exec rm -r "{}" +
+	@find . -type d -name ".pytest_cache" -exec rm -r "{}" +
 
 #################################################################################
 # PROJECT RULES                                                                 #


### PR DESCRIPTION
Before this, calling `make clean`  could produce the following error

```
find: ‘./.tox’: No such file or directory
```

Maybe because of that https://unix.stackexchange.com/questions/331696/removing-leading-dots-from-find-command-output-when-used-with-exec-echo-opti/537241

our approach is to the `+` operator to concatenate the results

https://unix.stackexchange.com/questions/195939/what-is-meaning-of-in-finds-exec-command

Also, `rf` was replaced by `r` for safety reasons.
