### PR TITLE
ci: fix vega/cml pipe communication

### DIFF
--- a/.github/workflows/cml.yml
+++ b/.github/workflows/cml.yml
@@ -38,12 +38,15 @@ jobs:
 
           echo "## Plots" >> report.md
           dvc plots diff --target reports/cfm.json --show-vega main > vega0.json
-          vl2png vega0.json -s 1.3 | cml-publish --md >> report.md
+          vl2png -s 1.3 vega0.json vega0.png
+          cml-publish vega0.png --md >> report.md
 
           dvc plots diff --target reports/roc.json --show-vega main > vega1.json
-          vl2png vega1.json -s 1.3 | cml-publish --md >> report.md
+          vl2png -s 1.3 vega1.json vega1.png
+          cml-publish vega1.png --md >> report.md
 
           dvc plots diff --target reports/prc.json --show-vega main > vega2.json
-          vl2png vega2.json -s 1.3 | cml-publish --md >> report.md
+          vl2png -s 1.3 vega2.json vega2.png
+          cml-publish vega2.png --md >> report.md
 
           cml-send-comment --update report.md


### PR DESCRIPTION
Before this commit sync issues between vega and cml commands could happen.

```
vega input args | cml-publish args >> file.md
```

If anything goes wrong with vl2png or the stream of the png is not finished before  cml-publish  call this will trigger a failure in the cml-publish. Thus, causing a failure in the vl2png process because there is no place to stream the png file


below, a log containing the error output

```
cml publish <asset>

Upload an image to build a report

Options:
      --help                      Show help                            [boolean]
      --version                   Show version number                  [boolean]
      --log                       Maximum log level
          [string] [choices: "error", "warn", "info", "debug"] [default: "info"]
      --md                        Output in markdown format [title ||
                                  name](url).                          [boolean]
  -t, --title                     Markdown title [title](url) or ![](url title).
                                                                        [string]
      --native, --gitlab-uploads  Uses driver's native capabilities to upload
                                  assets instead of CML's storage. Currently
                                  only available for GitLab CI.        [boolean]
      --rm-watermark              Avoid CML watermark.                 [boolean]
      --mime-type                 Specifies the mime-type. If not set guess it
                                  from the content.                     [string]
  -f, --file                      Append the output to the given file. Create it
                                  if does not exist.                    [string]
      --repo                      Specifies the repo to be used. If not
                                  specified is extracted from the CI ENV.
                                                                        [string]
      --token                     Personal access token to be used. If not
                                  specified, extracted from ENV REPO_TOKEN,
                                  GITLAB_TOKEN, GITHUB_TOKEN, or
                                  BITBUCKET_TOKEN.                      [string]
      --driver                    If not specify it infers it from the ENV.
                             [string] [choices: "github", "gitlab", "bitbucket"]

Not enough non-option arguments: got 0, need at least 1
node:events:498
      throw er; // Unhandled 'error' event
      ^

Error: write EPIPE
    at afterWriteDispatched (node:internal/stream_base_commons:160:15)
    at writeGeneric (node:internal/stream_base_commons:151:3)
    at Socket._writeGeneric (node:net:795:11)
    at Socket._write (node:net:807:8)
    at writeOrBuffer (node:internal/streams/writable:389:12)
    at _write (node:internal/streams/writable:330:10)
    at Socket.Writable.write (node:internal/streams/writable:334:10)
    at PNGStream.<anonymous> (/usr/local/lib/node_modules/vega-lite/bin/vl2png:11:36)
    at PNGStream.emit (node:events:520:28)
    at PNGStream.Readable.read (node:internal/streams/readable:527:10)
Emitted 'error' event on Socket instance at:
    at emitErrorNT (node:internal/streams/destroy:157:8)
    at emitErrorCloseNT (node:internal/streams/destroy:122:3)
    at processTicksAndRejections (node:internal/process/task_queues:83:21) {
  errno: -32,
  code: 'EPIPE',
  syscall: 'write'
}
Error: Process completed with exit code 1.
```