### PR TITLE
fix: wrong error handling and remove a danger anti-pattern

### DIFF
--- a/src/models/train_model.py
+++ b/src/models/train_model.py
@@ -47,12 +47,12 @@ def train(input_folder, model_folder, params=None):
     model_out_path = Path(f"{model_folder}/model.joblib").resolve()
 
     # Load the featurized data
-    train = joblib.load(train_in_path)
+    train_data = joblib.load(train_in_path)
 
     # Split the data into features and target
     X_train, y_train = (
-        train.drop(target, axis=1),
-        train.pop(target),
+        train_data.drop(target, axis=1),
+        train_data.pop(target),
     )
 
     # Instantiate the classifier

--- a/src/models/train_model.py
+++ b/src/models/train_model.py
@@ -11,13 +11,14 @@ import joblib
 import yaml
 
 
-def train(input_folder, model_folder):
+def train(input_folder, model_folder, params=None):
+    if params is None:
+        with open("params.yaml", "r", encoding="utf-8") as file:
+            params = yaml.load(file, Loader=yaml.SafeLoader)
 
-    with open("params.yaml", "r", encoding="utf-8") as file:
-        params = yaml.load(file, Loader=yaml.SafeLoader)
-        target = params["dataset"]["target"]
-        clf = params["train"]["clf"]
-        clf_params = params["train"]["clf_params"]
+    target = params["dataset"]["target"]
+    clf = params["train"]["clf"]
+    clf_params = params["train"]["clf_params"]
 
     # Path to the featurized train.joblib dataset
     train_in_path = Path(f"{input_folder}/train.joblib").resolve()

--- a/src/models/train_model.py
+++ b/src/models/train_model.py
@@ -20,21 +20,6 @@ def train(input_folder, model_folder, params=None):
     clf = params["train"]["clf"]
     clf_params = params["train"]["clf_params"]
 
-    # Path to the featurized train.joblib dataset
-    train_in_path = Path(f"{input_folder}/train.joblib").resolve()
-
-    # Path where the trained model will be stored
-    model_out_path = Path(f"{model_folder}/model.joblib").resolve()
-
-    # Load the featurized data
-    train = joblib.load(train_in_path)
-
-    # Split the data into features and target
-    X_train, y_train = (
-        train.drop(target, axis=1),
-        train.pop(target),
-    )
-
     # Dictionary of classifiers
     classifiers = {
         "RandomForestClassifier": RandomForestClassifier,
@@ -54,6 +39,21 @@ def train(input_folder, model_folder, params=None):
     # If there are invalid parameters, print an error message and exit
     if invalid_arg:
         raise ValueError(f"Error: Invalid parameters {invalid_arg}")
+
+    # Path to the featurized train.joblib dataset
+    train_in_path = Path(f"{input_folder}/train.joblib").resolve()
+
+    # Path where the trained model will be stored
+    model_out_path = Path(f"{model_folder}/model.joblib").resolve()
+
+    # Load the featurized data
+    train = joblib.load(train_in_path)
+
+    # Split the data into features and target
+    X_train, y_train = (
+        train.drop(target, axis=1),
+        train.pop(target),
+    )
 
     # Instantiate the classifier
     model = classifiers[clf](**clf_params)

--- a/src/models/train_model.py
+++ b/src/models/train_model.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """This module is responsible by the model creation and model training."""
-import sys
 import argparse
 from pathlib import Path
 from sklearn.ensemble import (
@@ -44,11 +43,7 @@ def train(input_folder, model_folder):
 
     # If the classifier is not in the dictionary, exit with error
     if clf not in classifiers.keys():
-        print(
-            f"Error: {classifiers[clf].__name__} is not a supported"
-            " classifier."
-        )
-        sys.exit(1)
+        raise ValueError(f"Classifier {clf} not found.")
 
     ## Verify if all parameters passed by the yaml are valid
     ## classifier parameters
@@ -57,11 +52,7 @@ def train(input_folder, model_folder):
 
     # If there are invalid parameters, print an error message and exit
     if invalid_arg:
-        print(
-            f"Error: {classifiers[clf].__name__} invalid parameters"
-            f" {invalid_arg}"
-        )
-        sys.exit(1)
+        raise ValueError(f"Error: Invalid parameters {invalid_arg}")
 
     # Instantiate the classifier
     model = classifiers[clf](**clf_params)

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,0 +1,25 @@
+import pytest
+import yaml
+from src.models.train_model import train
+
+
+def test_train_model_raise_exception():
+    with pytest.raises(ValueError):
+        # change params.yaml at run time just to test the exception
+        with open("params.yaml", "r", encoding="utf-8") as file:
+            params = yaml.load(file, Loader=yaml.SafeLoader)
+        params["train"]["clf"] = "WrongClassifier"
+        input_folder = "data/processed"
+        model_folder = "models"
+        train(input_folder, model_folder, params)
+
+
+def test_train_model__wrong_params_raise_exception():
+    with pytest.raises(ValueError):
+        # change params.yaml at run time just to test the exception
+        with open("params.yaml", "r", encoding="utf-8") as file:
+            params = yaml.load(file, Loader=yaml.SafeLoader)
+        params["train"]["clf_params"]["Invalid_Arg"] = "Invalid_Value"
+        input_folder = "data/processed"
+        model_folder = "models"
+        train(input_folder, model_folder, params)


### PR DESCRIPTION
Before this we have 
```python
  if clf not in classifiers.keys():
        print(
            f"Error: {classifiers[clf].__name__} is not a supported"
            " classifier."
        )
        sys.exit(1)
```
This is not correct because the condition is that `classifiers` don't have the `clf` key.
If you change the clf or clf_params inside of **params.yaml** you'll have this output

```
  File "src/models/train_model.py", line 93, in <module>
    train(**vars(args))
  File "src/models/train_model.py", line 48, in train
    f"Error: {classifiers[clf].__name__} is not a supported"
KeyError: 'RandomForestClassifier2'
make: *** [Makefile:81: train] Error 1
```
After this PR we will have
```
  File "src/models/train_model.py", line 85, in <module>
    train(**vars(args))
  File "src/models/train_model.py", line 32, in train
    raise ValueError(f"Classifier {clf} not found.")
ValueError: Classifier RandomForestClassifier2 not found.
```

Also, the correct way to do this is to raise a ValueError exception instead of sys.exit().
This PR also creates a test(tests/test_train.py) to assure that a correct exception is raised when necessary.

In addition, I'm fixing the following anti-pattern

def train](https://github.com/Schots/mlops_project/blob/0562950d287e0f444305cfc953187469733d1ebc/src/models/train_model.py#L15)
https://github.com/Schots/mlops_project/blob/0562950d287e0f444305cfc953187469733d1ebc/src/models/train_model.py#L30
